### PR TITLE
check for _viu existence before pointer dereference

### DIFF
--- a/platform/solo5/librumpnet_ukvmif/ukvmif_user.c
+++ b/platform/solo5/librumpnet_ukvmif/ukvmif_user.c
@@ -150,7 +150,7 @@ VIFHYPER_CREATE(const char *devstr, struct virtif_sc *vif_sc, uint8_t *enaddr,
 void
 VIFHYPER_RECEIVE(void)
 {
-	if (_viu->viu_rcvthr) {
+	if (_viu && _viu->viu_rcvthr) {
 		bmk_sched_wake(_viu->viu_rcvthr);
 	}
 }


### PR DESCRIPTION
Received SIGSEGV with `ukvm-bin --disk=x --net=tap100 helloer-rumprun.seccomp`
Signed-off-by: Sahil Suneja <sahilsuneja@gmail.com>