### PR TITLE
Lfs support plus tests nits

### DIFF
--- a/app-tools/rumprun-bake.conf
+++ b/app-tools/rumprun-bake.conf
@@ -64,6 +64,7 @@ fnoc
 conf _stdfs
 	create	"selection of file system drivers"
 	add	-lrumpfs_ffs			\
+		-lrumpfs_lfs			\
 		-lrumpfs_cd9660			\
 		-lrumpfs_ext2fs			\
 		-lrumpdev_disk			\

--- a/blk_test/Makefile
+++ b/blk_test/Makefile
@@ -43,8 +43,8 @@ run_ukvm: blk-rumprun.ukvm test.iso test.ext2
 .PHONY: run_seccomp
 run_seccomp: blk-rumprun.seccomp test.iso test.ext2
 	touch dummy
-	#../ukvm-bin.seccomp --disk=test.iso --net=tap100 blk-rumprun.seccomp '{"cmdline":"","blk":{"source":"etfs","path":"/dev/ld0a","fstype":"blk","mountpoint":"/test"}}'
-	../ukvm-bin.seccomp --disk=test.ext2 --net=tap100 blk-rumprun.seccomp '{"cmdline":"","blk":{"source":"etfs","path":"/dev/ld0a","fstype":"blk","mountpoint":"/test"}}'
+	../ukvm-bin.seccomp --disk=test.iso --net=tap100 blk-rumprun.seccomp '{"cmdline":"blk /test/aaaaaaaaaaaaaaax","blk":{"source":"etfs","path":"/dev/ld0a","fstype":"blk","mountpoint":"/test"}}'
+	../ukvm-bin.seccomp --disk=test.iso --net=tap100 blk-rumprun.seccomp '{"cmdline":"blk /test", "blk":{"source":"etfs","path":"/dev/ld0a","fstype":"blk","mountpoint":"/test"}}'
 	e2tail test.ext2:/bla
 
 .PHONY: run_ukvm_rr

--- a/blk_test/Makefile
+++ b/blk_test/Makefile
@@ -47,6 +47,12 @@ run_seccomp: blk-rumprun.seccomp test.iso test.ext2
 	../ukvm-bin.seccomp --disk=test.iso --net=tap100 blk-rumprun.seccomp '{"cmdline":"blk /test", "blk":{"source":"etfs","path":"/dev/ld0a","fstype":"blk","mountpoint":"/test"}}'
 	e2tail test.ext2:/bla
 
+.PHONY: run_seccomp_lfs
+run_seccomp_lfs: blk-rumprun.seccomp test.lfs
+	touch dummy
+	../ukvm-bin.seccomp --disk=test.lfs --net=tap100 blk-rumprun.seccomp '{"cmdline":"blk /test/aaaaaaaaaaaaaaax","blk":{"source":"etfs","path":"/dev/ld0a","fstype":"blk","mountpoint":"/test"}}'
+	../ukvm-bin.seccomp --disk=test.lfs --net=tap100 blk-rumprun.seccomp '{"cmdline":"blk /test", "blk":{"source":"etfs","path":"/dev/ld0a","fstype":"blk","mountpoint":"/test"}}'
+
 .PHONY: run_ukvm_rr
 run_ukvm_rr: ukvm_rr
 	touch dummy

--- a/blk_test/blk.c
+++ b/blk_test/blk.c
@@ -3,26 +3,48 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <assert.h>
+#include <dirent.h>
+
+int list_dirs(char *path)
+{
+	struct dirent *de;
+	DIR *dr = opendir(path);
+
+	if (dr == NULL) { // opendir returns NULL if couldn't open directory
+		return 1;
+	}
+
+	while ((de = readdir(dr)) != NULL)
+		puts(de->d_name);
+
+	closedir(dr);
+	return 0;
+}
 
 int main(int argc , char *argv[])
 {
 	int l, n;
 	char buf[80];
-	int f = open("/test/aaaaaaaaaaaaaaax", O_RDONLY);
-	while ((n=read(f,buf,80)) > 0)
-		write(1,buf,n);
-	close(f);
+	int f;
+	char name[256];
 
-	f = open("/test/bla", O_CREAT|O_WRONLY);
-	assert(f != -1);
-	write(f, "bla\n", 4);
-	close(f);
+	if (argc < 2) {
+		printf("usage: blk [file|dir]");
+	}
 
-	f = open("/dev/random", O_RDONLY);
-	assert(f != -1);
-	n=read(f,buf,8);
-	write(1,buf,n);
-	close(f);
+	strcpy(name, argv[1]);
+
+	if (list_dirs(name) == 0) {
+		return 0;
+	}
+
+	// not a directory, print file contents
+	f = open(name, O_RDONLY);
+	if (f > 0) {
+		while ((n=read(f,buf,80)) > 0)
+			write(1,buf,n);
+		close(f);
+	}
 
 	return 0;
 }

--- a/lib/librumprun_base/config.c
+++ b/lib/librumprun_base/config.c
@@ -36,6 +36,7 @@
 
 #include <ufs/ufs/ufsmount.h>
 #include <isofs/cd9660/cd9660_mount.h>
+#include <ufs/lfs/lfs.h>
 
 #include <dev/vndvar.h>
 
@@ -523,13 +524,16 @@ mount_blk(const char *dev, const char *mp)
 {
 	struct ufs_args mntargs_ufs = { .fspec = __UNCONST(dev) };
 	struct iso_args mntargs_iso = { .fspec = dev };
+	struct ulfs_args mntargs_ulfs = { .fspec = __UNCONST(dev) };
 
-	if (mount(MOUNT_FFS, mp, MNT_UNION, &mntargs_ufs, sizeof(mntargs_ufs)) == 0)
-		return true;
-	if (mount(MOUNT_EXT2FS, mp, MNT_UNION, &mntargs_ufs, sizeof(mntargs_ufs)) == 0)
+	if (mount(MOUNT_LFS, mp, MNT_UNION, &mntargs_ulfs, sizeof(mntargs_ulfs)) == 0)
 		return true;
 	if (mount(MOUNT_CD9660,
 	    mp, MNT_RDONLY|MNT_UNION, &mntargs_iso, sizeof(mntargs_iso)) == 0)
+		return true;
+	if (mount(MOUNT_FFS, mp, MNT_UNION, &mntargs_ufs, sizeof(mntargs_ufs)) == 0)
+		return true;
+	if (mount(MOUNT_EXT2FS, mp, MNT_UNION, &mntargs_ufs, sizeof(mntargs_ufs)) == 0)
 		return true;
 
 	return false;

--- a/rootfs_mount_test/rootfs.c
+++ b/rootfs_mount_test/rootfs.c
@@ -27,6 +27,7 @@ int main(int argc , char *argv[])
 {
 	int i = 1;
 	int n;
+	int f;
 	char buf[80];
 
 	char cwd[1024];
@@ -37,7 +38,7 @@ int main(int argc , char *argv[])
 
 	list_dirs("/");
 
-	int f = open("/tmp/bla", O_CREAT|O_RDWR);
+	f = open("/tmp/bla", O_CREAT|O_RDWR);
 	assert(f != -1);
 	write(f, "123\n", 4);
 	lseek(f, 0, SEEK_SET);
@@ -47,6 +48,13 @@ int main(int argc , char *argv[])
 	close(f);
 
 	list_dirs("/tmp");
+	list_dirs("/dev");
+
+	f = open("/dev/urandom", O_RDONLY);
+	assert(f != -1);
+	n=read(f,buf,8);
+	write(1,buf,n);
+	close(f);
 
 	return 0;
 }


### PR DESCRIPTION
3 changes:
- adding support for LFS disks: adding the lfs library, and mount(LFS) to rumprun setup.
- blk_test is more useful now: it gets a path as an arg and just prints the file content if file, or sub-files if directory.
- rootfs_mount_test now checks that /dev/urandom is present in the unikernel FS.