### PR TITLE
Solo5 changes for spt

### DIFF
--- a/global.mk
+++ b/global.mk
@@ -17,6 +17,7 @@ CFLAGS+= -Werror
 endif
 
 LDFLAGS.x86_64.hw= -z max-page-size=0x1000
+LDFLAGS.x86_64.solo5= -z max-page-size=0x1000
 
 ifeq (${BUILDRR},true)
 INSTALLDIR=     ${RROBJ}/dest.stage


### PR DESCRIPTION
A couple of changes needed to point to the latest upstream solo5 new tender: SPT. These can still be used in the current nabla-containers/solo5 repo, so merging without pointing to the latest solo5 is safe (confirmed it as well).

The changes are:
1. SPT only allows block io of size block-size (currently 512 Bytes). This changes splits bigger IOs into smaller 512 chunks. In the case of failure, the IO is returned immediately via `biodone(donearg, curr_off - off, BMK_EIO);` where `curr_off - off` is the number of successful bytes. Hopefully the FS on top can handle this correctly (haven't confirmed).
2. The final ELF (after `rump-bake`) has the first segment starting at offset 0. The first page (offset 0) can't hold any code (it's the NULL page), so the current nabla-containers/solo5 repo just ignores the first page (here: https://github.com/nabla-containers/solo5/blob/ukvm-linux-seccomp/ukvm/ukvm_elf.c#L60-L64). The latest solo5 does not do that (which is the right thing to do). Turns out that the way to tell the linker to not use offset 0 is to set the page size to something larger than 0, with `--max-page-size=0x1000`. And that's what the second commit of this PR does.