### PR TITLE
Fix tests: build of non-solo5 platforms should use regular TLS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,8 @@ before_script:
 env:
   - PLATFORM=hw MACHINE=x86_64 TESTS=qemu EXTRAFLAGS=
   - PLATFORM=hw MACHINE=i486 ELF=elf TESTS=qemu EXTRAFLAGS='-- -F ACLFLAGS=-m32 -F ACLFLAGS=-march=i686'
-  - PLATFORM=xen MACHINE=x86_64 TESTS=none EXTRAFLAGS=
-  - PLATFORM=xen MACHINE=i486 ELF=elf TESTS=none EXTRAFLAGS='-- -F ACLFLAGS=-m32'
   - PLATFORM=hw MACHINE=x86_64 TESTS=qemu EXTRAFLAGS= CXX='false'
   - PLATFORM=hw MACHINE=x86_64 TESTS=none KERNONLY=-k EXTRAFLAGS= 
-  - PLATFORM=xen MACHINE=x86_64 TESTS=none KERNONLY=-k EXTRAFLAGS=
 
 script:
   - git submodule update --init
@@ -25,5 +22,6 @@ script:
   - . ./myobj/config
   - ./tests/buildtests.sh ${KERNONLY}
   - ./tests/runtests.sh ${TESTS}
+
 
 # touch me to force a travis rebuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,18 +26,4 @@ script:
   - ./tests/buildtests.sh ${KERNONLY}
   - ./tests/runtests.sh ${TESTS}
 
-notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#rumpkernel-builds"
-    template:
-      - '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}'
-    skip_join: true
-    use_notice: true
-  email:
-    recipients:
-      - rumpkernel-builds@freelists.org
-    on_success: always
-    on_failure: always
-
 # touch me to force a travis rebuild


### PR DESCRIPTION
This PR fixes the tests for qemu which are currently failing on the TLS tests. They are failing because they were built without segment based TLS support. solo5 does not support TLS, so it was mistakenly disabled for all platforms.

Bonus: was also increasing the clock frequency for all platforms, when just solo5 needs it.