### PR TITLE
Point to upstream solo5/solo5 and enable solo5 tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src-netbsd"]
 	path = src-netbsd
 	url = https://github.com/rumpkernel/src-netbsd
+[submodule "solo5"]
+	path = solo5
+	url = https://github.com/Solo5/solo5.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,11 @@ compiler:
 
 before_script:
   - sudo apt-get update -y
-  - sudo apt-get install qemu-kvm libxen-dev -y
+  - sudo apt-get install qemu-kvm libxen-dev libseccomp-dev -y
   - sudo apt-get install --only-upgrade binutils gcc -y
 
 env:
+  - PLATFORM=solo5 MACHINE=x86_64 TESTS=spt EXTRAFLAGS=
   - PLATFORM=hw MACHINE=x86_64 TESTS=qemu EXTRAFLAGS=
   - PLATFORM=hw MACHINE=i486 ELF=elf TESTS=qemu EXTRAFLAGS='-- -F ACLFLAGS=-m32 -F ACLFLAGS=-march=i686'
   - PLATFORM=hw MACHINE=x86_64 TESTS=qemu EXTRAFLAGS= CXX='false'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: c
 cache: ccache

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 build:
-	./build-rr.sh -j4 -d rumprun-solo5 -o ./obj solo5 build
-	./build-rr.sh -j4 -d rumprun-solo5 -o ./obj solo5 install
+	./build-rr.sh -j4 -d rumprun-solo5 -o ./obj solo5
 
 build_hw:
-	CC=gcc ./build-rr.sh -j4 -d rumprun-solo5 -o ./obj hw
+	./build-rr.sh -j4 -d rumprun-solo5 -o ./obj hw
 
 clean:
 	rm -rf obj*
 	rm -rf rumprun
 	rm -rf rumprun-solo5*
+	make -C solo5 clean

--- a/app-tools/rumprun-bake.conf
+++ b/app-tools/rumprun-bake.conf
@@ -103,28 +103,19 @@ conf _miconf
 			_sysproxy
 fnoc
 
-# -lsolo5_ukvm, -lsolo5_rr, and -lsolo5_seccomp are created in ROOT/Makefile
-
-conf solo5_ukvm_net
-	create		"solo5-ukvm with network support targets"
+conf solo5_hvt
+	create		"Solo5 HVT (hardware virtualized tender). Formerly known as ukvm."
 	assimilate	_miconf
 	add		-lrumpfs_kernfs		\
 			-lrumpnet_ukvmif	\
-			-lsolo5_ukvm
+			-lsolo5_hvt
 fnoc
 
-conf solo5_ukvm_rr_net
-	create		"solo5-rr with network support targets"
+conf solo5_spt
+	create		"Solo5 SPT (sandboxed process tender). Formerly known as solo5-seccomp."
 	assimilate	_miconf
 	add		-lrumpnet_ukvmif	\
-			-lsolo5_rr
-fnoc
-
-conf solo5_ukvm_seccomp
-	create		"solo5-seccomp with network support targets"
-	assimilate	_miconf
-	add		-lrumpnet_ukvmif	\
-			-lsolo5_seccomp
+			-lsolo5_spt
 fnoc
 
 conf _virtio_scsi

--- a/build-rr.sh
+++ b/build-rr.sh
@@ -359,7 +359,7 @@ buildrump ()
 	#    important in solo5 and not qemu or xen is that solo5
 	#    only supports polling IO (it has no interrupts). So,
 	#    very frequent polling, done every clock tick, is good.
-	if [ "${PLATFORM}" == "solo5" ]; then
+	if [ "${PLATFORM}" = "solo5" ]; then
 		FREQ_SETUP="-F CFLAGS=-DHZ=100"
 		RR_USE_TLS="no"
 	else

--- a/build-rr.sh
+++ b/build-rr.sh
@@ -57,6 +57,7 @@ helpme ()
 }
 
 BUILDRUMP=$(pwd)/buildrump.sh
+SOLO5SRC=$(pwd)/solo5
 
 # overriden by script if true
 HAVECXX=false
@@ -200,7 +201,8 @@ checksubmodules ()
 	# We assume that if the git submodule command fails, it's because
 	# we're using external $RUMPSRC.
 	if git submodule status ${RUMPSRC} 2>/dev/null | grep -q '^-' \
-	    || git submodule status ${BUILDRUMP} 2>/dev/null | grep -q '^-';
+	    || git submodule status ${BUILDRUMP} 2>/dev/null | grep -q '^-' \
+	        || git submodule status ${SOLO5SRC} 2>/dev/null | grep -q '^-';
 	then
 		echo '>>'
 		echo '>> submodules missing.  run "git submodule update --init"'
@@ -476,6 +478,23 @@ buildpci ()
 	fi
 }
 
+installsolo5libs ()
+{
+
+	SPTLIB=${RRDEST}/rumprun-${MACHINE_GNU_ARCH}/lib/rumprun-${PLATFORM}/libsolo5_spt.a
+	HVTLIB=${RRDEST}/rumprun-${MACHINE_GNU_ARCH}/lib/rumprun-${PLATFORM}/libsolo5_hvt.a
+
+	# The reason for this very strange objcopy is that both solo5.o and
+	# rumprun's libc.a define a stack guard.
+	objcopy --redefine-sym __stack_chk_fail=__stack_chk_fail_solo5 \
+		--redefine-sym __stack_chk_guard=__stack_chk_guard_solo5 \
+		solo5/bindings/spt/solo5_spt.o ${SPTLIB}
+
+	objcopy --redefine-sym __stack_chk_fail=__stack_chk_fail_solo5 \
+		--redefine-sym __stack_chk_guard=__stack_chk_guard_solo5 \
+		solo5/bindings/hvt/solo5_hvt.o ${HVTLIB}
+}
+
 wraponetool ()
 {
 
@@ -504,6 +523,8 @@ makeconfig ()
 	echo "TOOLTUPLE=${quote}${TOOLTUPLE}${quote}" >> ${1}
 	echo "KERNONLY=${quote}${KERNONLY}${quote}" >> ${1}
 	echo "PLATFORM=${quote}${PLATFORM}${quote}" >> ${1}
+
+	[ "${PLATFORM}" = "solo5" ] && ( echo "SOLO5SRC=${quote}${SOLO5SRC}${quote}" >> ${1} )
 
 	echo "RRDEST=${quote}${RRDEST}${quote}" >> ${1}
 	echo "RROBJ=${quote}${RROBJ}${quote}" >> ${1}
@@ -542,6 +563,8 @@ dobuild ()
 	${KERNONLY} || builduserspace
 
 	buildpci
+
+	[ "${PLATFORM}" = "solo5" ] && make -C ${SOLO5SRC}
 
 	# do final build of the platform bits
 	( cd ${PLATFORMDIR} \
@@ -585,6 +608,8 @@ doinstall ()
 		find . -maxdepth 1 \! -path . \! -path ./include\* \
 		    | xargs tar -cf -
 	) | (cd ${RRDEST} ; tar -xf -)
+
+	[ "${PLATFORM}" = "solo5" ] && installsolo5libs
 
 	# copy include to destdir/include/rumprun
 	( cd ${STAGING}/include ; tar -cf - . ) \

--- a/tests/buildtests.sh
+++ b/tests/buildtests.sh
@@ -46,6 +46,9 @@ test_apptools()
 	xen)
 		RUMPBAKE_PLATFORM='xen_pv'
 		;;
+	solo5)
+		RUMPBAKE_PLATFORM='solo5_spt'
+		;;
 	*)
 		echo ">> unknown platform \"$PLATFORM\""
 		exit 1


### PR DESCRIPTION
1. Adding solo5/solo5 master repo as a submodule.
2. Adding solo5 to runtests.sh and updated travis to run them.
3. Now build-rr.sh builds and copies the solo5 libraries to their location. There is an objcopy to change stack guard symbols that were in conflict with the rumprun libc.
4. The old bake rules were called ukvm-* and seccomp-*. Changed that to solo5-hvt and solo5-spt.