### PR TITLE
Changes for solo5 hvt (previously ukvm) and tests

### DIFF
--- a/build-rr.sh
+++ b/build-rr.sh
@@ -374,7 +374,7 @@ buildrump ()
 		TLSCFLAGS="-F CFLAGS=-DRR_USE_TLS"
 	else
 		CURLWP_METHOD=hypercall
-		TLSCFLAGS="-F CFLAGS=-D_PTHREAD_GETTCB_EXT=_lwp_get_tls_tcb"
+		TLSCFLAGS="-F CFLAGS=-D_PTHREAD_GETTCB_EXT=_lwp_get_tls_tcb -F CFLAGS=-fno-stack-protector"
 	fi
 
 	extracflags=

--- a/lib/libbmk_core/sched.c
+++ b/lib/libbmk_core/sched.c
@@ -339,9 +339,9 @@ sched_switch(struct bmk_thread *prev, struct bmk_thread *next)
 
 	if (scheduler_hook)
 		scheduler_hook(prev->bt_cookie, next->bt_cookie);
+#ifdef RR_USE_TLS
 	bmk_platform_cpu_sched_settls(&next->bt_tcb);
-
-#ifndef RR_USE_TLS
+#else
         // Just in case. Let's add a compiler mem barrier
 	__asm__ __volatile__("" ::: "memory");
 	bmk_current = next;

--- a/platform/solo5/arch/amd64/machdep.c
+++ b/platform/solo5/arch/amd64/machdep.c
@@ -27,6 +27,7 @@
 
 #include <bmk-core/printf.h>
 #include <bmk-core/sched.h>
+#include <assert.h>
 
 void
 bmk_platform_cpu_sched_settls(struct bmk_tcb *next)
@@ -38,5 +39,7 @@ bmk_platform_cpu_sched_settls(struct bmk_tcb *next)
 		"a" ((uint32_t)(next->btcb_tp)),
 		"d" ((uint32_t)(next->btcb_tp >> 32))
 	);
+#else
+	assert(0); /* Should not get here */
 #endif
 }

--- a/tests/buildtests.sh
+++ b/tests/buildtests.sh
@@ -12,14 +12,18 @@ set -e
 TESTMODE=apptools
 TESTCONFIGURE=true
 TESTCMAKE=$(which cmake || echo "")
+RUMPBAKE_PLATFORM=
 
-while getopts 'kqh' opt; do
+while getopts 'kqhp:' opt; do
 	case "$opt" in
 	'k')
 		TESTMODE=kernonly
 		;;
 	'q')
 		TESTCONFIGURE=false
+		;;
+	'p')
+		RUMPBAKE_PLATFORM="${OPTARG}"
 		;;
 	'h'|'?')
 		echo "$0 [-k|-q]"
@@ -39,20 +43,22 @@ cd "$(dirname $0)"
 test_apptools()
 {
 
-	case ${PLATFORM} in
-	hw)
-		RUMPBAKE_PLATFORM='hw_generic'
-		;;
-	xen)
-		RUMPBAKE_PLATFORM='xen_pv'
-		;;
-	solo5)
-		RUMPBAKE_PLATFORM='solo5_spt'
-		;;
-	*)
-		echo ">> unknown platform \"$PLATFORM\""
-		exit 1
-	esac
+	if [ -z "$RUMPBAKE_PLATFORM" ]; then
+		case ${PLATFORM} in
+		hw)
+			RUMPBAKE_PLATFORM='hw_generic'
+			;;
+		xen)
+			RUMPBAKE_PLATFORM='xen_pv'
+			;;
+		solo5)
+			RUMPBAKE_PLATFORM='solo5_spt'
+			;;
+		*)
+			echo ">> unknown platform \"$PLATFORM\""
+			exit 1
+		esac
+	fi
 
 	export PATH="${RRDEST}/bin:${PATH}"
 	export RUMPBAKE_PLATFORM

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -47,7 +47,10 @@ ENDMAGIC='=== RUMPRUN 12345 TES-TER 54321 EOF ==='
 
 OPT_SUDO=
 
+# SPT is built with all modules
 SOLO5_SPT=${SOLO5SRC}/tenders/spt/solo5-spt
+# We need an HVT binary built with just the blk module
+SOLO5_HVT=${SOLO5SRC}/tests/test_blk/solo5-hvt
 
 die ()
 {
@@ -81,11 +84,18 @@ runguest ()
 	# img2=$3
 
 	[ -n "${img1}" ] || die runtest without a disk image
-	if [ "${STACK}" = "spt" ]; then
+	case "${STACK}" in
+	spt)
 		cookie=$(${SOLO5_SPT} --disk=${img1} ${testprog} '{"cmdline":"testprog __test","blk":{"source":"etfs","path":"ld0d","fstype":"blk"}}')
-	else
+		;;
+	hvt)
+		cookie=$(${SOLO5_HVT} --disk=${img1} ${testprog} '{"cmdline":"testprog __test","blk":{"source":"etfs","path":"ld0d","fstype":"blk"}}')
+		;;
+	*)
 		cookie=$(${RUMPRUN} ${OPT_SUDO} ${STACK} -b ${img1} ${testprog} __test)
-	fi
+		;;
+	esac
+
 	if [ $? -ne 0 -o -z "${cookie}" ]; then
 		TEST_RESULT=ERROR
 		TEST_ECODE=-2


### PR DESCRIPTION
This is mainly to fix #13 . The fix is to disable stack protection (more in the commit message).

On top of that it adds tests for hvt and makes sure that the settls function is not called in solo5.

The way to run the HVT tests is:
```
cd tests/
./buildtests.sh -p solo5_hvt
./runtests.sh hvt
```
Can't run this in travis as we need KVM for HVT.