### PR TITLE
Add aarch64 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/nabla-containers/buildrump.sh.git
 [submodule "src-netbsd"]
 	path = src-netbsd
-	url = https://github.com/rumpkernel/src-netbsd
+	url = https://github.com/cloudkernels/src-netbsd.git
 [submodule "solo5"]
 	path = solo5
 	url = https://github.com/Solo5/solo5.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
-[submodule "buildrump.sh"]
-	path = buildrump.sh
-	url = https://github.com/nabla-containers/buildrump.sh.git
-[submodule "src-netbsd"]
-	path = src-netbsd
-	url = https://github.com/cloudkernels/src-netbsd.git
 [submodule "solo5"]
 	path = solo5
 	url = https://github.com/Solo5/solo5.git
+[submodule "buildrump.sh"]
+	path = buildrump.sh
+	url = https://github.com/cloudkernels/buildrump.sh
+[submodule "src-netbsd"]
+	path = src-netbsd
+	url = https://github.com/cloudkernels/src-netbsd

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,30 @@ language: c
 cache: ccache
 compiler:
   - gcc
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-6
+      - g++-6
+
+git:
+  submodules: false
 
 before_script:
   - sudo apt-get update -y
   - sudo apt-get install qemu-kvm libxen-dev libseccomp-dev bats genisoimage sudo iproute2 wget -y
   - sudo apt-get install --only-upgrade binutils gcc -y
+  - bash travis_wait.sh 60 git submodule update --init
 
 env:
   - PLATFORM=solo5 MACHINE=x86_64 TESTS=spt EXTRAFLAGS=
-  - PLATFORM=hw MACHINE=x86_64 TESTS=qemu EXTRAFLAGS=
-  - PLATFORM=hw MACHINE=i486 ELF=elf TESTS=qemu EXTRAFLAGS='-- -F ACLFLAGS=-m32 -F ACLFLAGS=-march=i686'
-  - PLATFORM=hw MACHINE=x86_64 TESTS=qemu EXTRAFLAGS= CXX='false'
   - PLATFORM=hw MACHINE=x86_64 TESTS=none KERNONLY=-k EXTRAFLAGS= 
 
 script:
-  - git submodule update --init
-  - ./build-rr.sh -o myobj -j16 -qq ${KERNONLY} ${PLATFORM} ${EXTRAFLAGS}
+  - export CC=gcc-6
+  - NOGCCERROR=1 ./build-rr.sh -o myobj -j16 -qq ${KERNONLY} ${PLATFORM} ${EXTRAFLAGS}
   - . ./myobj/config
   - ./tests/buildtests.sh ${KERNONLY}
   - ./tests/runtests.sh ${TESTS}

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
+NCORES = $(shell grep -c ^processor /proc/cpuinfo)
+DESTDIR ?= rumprun-solo5
+
 build:
-	./build-rr.sh -j4 -d rumprun-solo5 -o ./obj solo5
+	./build-rr.sh -j$(NCORES) -d ${DESTDIR} -o ./obj solo5
 
 build_hw:
-	./build-rr.sh -j4 -d rumprun-solo5 -o ./obj hw
+	CC=gcc ./build-rr.sh -j$(NCORES) -d rumprun-solo5 -o ./obj hw
 
 clean:
 	rm -rf obj*

--- a/app-tools/Makefile
+++ b/app-tools/Makefile
@@ -83,6 +83,7 @@ ${TOOLOBJ}/${2}: ${1} Makefile ${TOOLOBJ}
 		-e 's#!PLATFORM!#$(PLATFORM)#g;'			\
 		-e 's#!CPPFLAGS!#$(BUILDRUMP_TOOL_CPPFLAGS)#g;'		\
 		-e 's#!CFLAGS!#$(BUILDRUMP_TOOL_CFLAGS)#g;'		\
+		-e 's#!EXTRACCFLAGS!#$(EXTRACCFLAGS)#g;'		\
 		-e 's#!CXXFLAGS!#$(BUILDRUMP_TOOL_CXXFLAGS)#g;'		\
 		-e 's#!LDFLAGS_BAKE!#$(LDFLAGS_BAKE)#g;'
 	chmod 755 $$@

--- a/app-tools/cc.in
+++ b/app-tools/cc.in
@@ -96,7 +96,7 @@ ferment)
 	${CC} ${CFLAGS} -no-integrated-cpp \
 	    --sysroot !DESTDIR!/rumprun-!MACHINE_GNU_ARCH! \
 	    -specs=!DESTDIR!/rumprun-!MACHINE_GNU_ARCH!/lib/specs-compile_or_ferment \
-	    -Wl,-r -Wl,-u,main \
+	    !EXTRACCFLAGS! -Wl,-r -Wl,-u,main \
 	    "$@" !DESTDIR!/rumprun-!MACHINE_GNU_ARCH!/share/!TOOLTUPLE!-recipe.s ${EXTRALIBS} || die
 
 	# If the presumed output file did not change, and the compiler

--- a/app-tools/cookfs.in
+++ b/app-tools/cookfs.in
@@ -164,7 +164,7 @@ processonefile ()
 	ln -sf -- "${fabs}" ${LINKPATH}
 
 	${RUMPRUN_COOKFS_CC} !CFLAGS! !CPPFLAGS! -nostdlib		\
-	    -Wl,-r,-b,binary -o ${TMPDIR}/d${fn}.o ${LINKPATH}
+	    !EXTRACCFLAGS! -Wl,-r,-b,binary -o ${TMPDIR}/d${fn}.o ${LINKPATH}
 
 	${RUMPRUN_COOKFS_OBJCOPY}					\
 	    --redefine-sym ${LINKPATH_BIN}_start=${rf}_start		\
@@ -233,7 +233,7 @@ exec 1>&3 3>&-
 unset IFS
 
 ${RUMPRUN_COOKFS_CC} !CFLAGS! !CPPFLAGS! -I${RUMPRUN_COOKFS_INCDIR}	\
-    -nostdlib -Wl,-r -o ${TMPDIR}/fin.o ${TMPDIR}/d*.o ${TMPDIR}/constr.c
+    -nostdlib !EXTRACCFLAGS! -Wl,-r -o ${TMPDIR}/fin.o ${TMPDIR}/d*.o ${TMPDIR}/constr.c
 ${RUMPRUN_COOKFS_OBJCOPY} ${LSYM} ${TMPDIR}/fin.o ${OUTFILE}
 
 totsize=$(${RUMPRUN_COOKFS_SIZE} ${OUTFILE} | awk 'NR == 2{print $4}')

--- a/app-tools/rumprun-bake.in
+++ b/app-tools/rumprun-bake.in
@@ -397,8 +397,9 @@ done
 
 MACHINE_GNU_ARCH=${RUMPBAKE_TUPLE%%-*}
 
+
 # Final link using cc to produce the unikernel image.
-${runcmd} ${RUMPBAKE_BACKINGCC} ${RUMPBAKE_CFLAGS}			\
+${runcmd} ${RUMPBAKE_BACKINGCC} ${RUMPBAKE_CFLAGS} !EXTRACCFLAGS!	\
     --sysroot ${RUMPBAKE_TOOLDIR}/rumprun-${MACHINE_GNU_ARCH}		\
     -specs=${RUMPBAKE_TOOLDIR}/rumprun-${MACHINE_GNU_ARCH}/lib/rumprun-${PLATFORM}/specs-bake \
     -o ${OUTPUT} ${allobjs}						\

--- a/build-rr.sh
+++ b/build-rr.sh
@@ -385,7 +385,7 @@ buildrump ()
 
 	# Disable new errors on GCC 7 which break netbsd-src compilation
 	#
-	[ `gcc -dumpversion | cut -f1 -d.` -ge 7 ] \
+	[ `${CC} -dumpversion | cut -f1 -d.` -ge 7 ] \
 		&& extracflags="$extracflags -F CPPFLAGS=-Wimplicit-fallthrough=0"
 
 

--- a/build-rr.sh
+++ b/build-rr.sh
@@ -379,7 +379,14 @@ buildrump ()
 
 	extracflags=
 	[ "${MACHINE_GNU_ARCH}" = "x86_64" ] \
-	    && extracflags="-F CFLAGS=-mno-red-zone"
+	    && extracflags='-F CFLAGS=-mno-red-zone'
+
+	# Disable new errors on GCC 7 which break netbsd-src compilation
+	#
+	[ `gcc -dumpversion | cut -f1 -d.` -ge 7 ] \
+		&& extracflags="$extracflags -F CPPFLAGS=-Wimplicit-fallthrough=0"
+
+
 	extracflags="${extracflags} ${TLSCFLAGS} ${FREQ_SETUP}"
 
 	# build tools

--- a/build-rr.sh
+++ b/build-rr.sh
@@ -542,6 +542,14 @@ makeconfig ()
 	else
 		echo "CONFIG_CXX=no" >> ${1}
 	fi
+
+	# Check for if compiler supports -no-pie and save to EXTRACCFLAGS
+	gccnopie=
+	if [ -z "`echo 'int p=1;' | ${CC} -no-pie -S -o /dev/null -x c - 2>&1`" ]; then
+		gccnopie=-no-pie
+	fi
+	echo "EXTRACCFLAGS=${quote}${gccnopie}${quote}" >> ${1}
+
 }
 
 dobuild ()

--- a/build-rr.sh
+++ b/build-rr.sh
@@ -292,12 +292,12 @@ setvars ()
 		RROBJ="./obj-${MACHINE}-${PLATFORM}${GITBRANCH}${EXTSRC}"
 		${KERNONLY} && RROBJ="${RROBJ}-kernonly"
 	fi
+	abspath RROBJ
 	STAGING="${RROBJ}/dest.stage"
 	BROBJ="${RROBJ}/buildrump.sh"
 	RUMPTOOLS="${RROBJ}/rumptools"
 
 	abspath RRDEST
-	abspath RROBJ
 	abspath RUMPSRC
 }
 
@@ -394,7 +394,7 @@ buildrump ()
 	echo '>> further setup for rumprun build'
 	echo '>>'
 
-	RUMPMAKE=$(pwd)/${RUMPTOOLS}/rumpmake
+	RUMPMAKE=${RUMPTOOLS}/rumpmake
 
 	TOOLTUPLE=$(${RUMPMAKE} -f bsd.own.mk \
 	    -V '${MACHINE_GNU_PLATFORM:S/--netbsd/-rumprun-netbsd/}')
@@ -517,7 +517,7 @@ makeconfig ()
 	echo "BUILDRUMP=${quote}${BUILDRUMP}${quote}" > ${1}
 	echo "RUMPSRC=${quote}${RUMPSRC}${quote}" >> ${1}
 	echo "RUMPMAKE=${quote}${RUMPMAKE}${quote}" >> ${1}
-	echo "BUILDRUMP_TOOLFLAGS=${quote}$(pwd)/${RUMPTOOLS}/toolchain-conf.mk${quote}" >> ${1}
+	echo "BUILDRUMP_TOOLFLAGS=${quote}${RUMPTOOLS}/toolchain-conf.mk${quote}" >> ${1}
 	echo "MACHINE=${quote}${MACHINE}${quote}" >> ${1}
 	echo "MACHINE_GNU_ARCH=${quote}${MACHINE_GNU_ARCH}${quote}" >> ${1}
 	echo "TOOLTUPLE=${quote}${TOOLTUPLE}${quote}" >> ${1}

--- a/build-rr.sh
+++ b/build-rr.sh
@@ -56,6 +56,8 @@ helpme ()
 	exit 1
 }
 
+CC=${CC:-cc}
+
 BUILDRUMP=$(pwd)/buildrump.sh
 SOLO5SRC=$(pwd)/solo5
 
@@ -311,7 +313,7 @@ checktools ()
 	delay=5
 
 	# check that gcc is modern enough
-	vers=$(${CC:-cc} -E -dM - < /dev/null | LANG=C awk '
+	vers=$(${CC} -E -dM - < /dev/null | LANG=C awk '
 	    /__GNUC__/ {version += 100*$3}
 	    /__GNUC_MINOR__/ {version += $3}
 	    END { print version; if (version) exit 0; exit 1; }') \
@@ -328,7 +330,7 @@ checktools ()
 	fi
 
 	# check that ld is modern enough
-	vers=$(${CC:-cc} -Wl,--version 2>&1 | LANG=C awk '
+	vers=$(${CC} -Wl,--version 2>&1 | LANG=C awk '
 	    /GNU ld/{version += 100*$NF}
 	    END { print version; if (version) exit 0; exit 1; }') \
 		|| die unable to probe ld version

--- a/global.mk
+++ b/global.mk
@@ -24,3 +24,6 @@ INSTALLDIR=     ${RROBJ}/dest.stage
 else
 INSTALLDIR=     ${RRDEST}
 endif
+
+cc-option = $(shell if [ -z "`echo 'int p=1;' | $(CC) $(1) -S -o /dev/null -x c - 2>&1`" ]; \
+                       then echo y; else echo n; fi)

--- a/lib/libbmk_core/arch/aarch64/Makefile.inc
+++ b/lib/libbmk_core/arch/aarch64/Makefile.inc
@@ -1,0 +1,5 @@
+MYDIR:=	${.PARSEDIR}
+.PATH:	${MYDIR}
+
+SRCS+=	cpu_sched_switch.S 
+SRCS+=	cpu_sched.c

--- a/lib/libbmk_core/arch/aarch64/cpu_sched.c
+++ b/lib/libbmk_core/arch/aarch64/cpu_sched.c
@@ -1,0 +1,59 @@
+/*
+ ****************************************************************************
+ * (C) 2005 - Grzegorz Milos - Intel Research Cambridge
+ ****************************************************************************
+ *
+ *        File: sched.c
+ *      Author: Grzegorz Milos
+ *     Changes: Robert Kaiser
+ *
+ *        Date: Aug 2005
+ *
+ * Environment: Xen Minimal OS
+ * Description: simple scheduler for Mini-Os
+ *
+ * The scheduler is non-preemptive (cooperative), and schedules according
+ * to Round Robin algorithm.
+ *
+ ****************************************************************************
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <bmk-core/core.h>
+#include <bmk-core/sched.h>
+
+void
+bmk_cpu_sched_create(struct bmk_thread *thread, struct bmk_tcb *tcb,
+	void (*f)(void *), void *arg,
+	void *stack_base, unsigned long stack_size)
+{
+	void *stack_top = (char *)stack_base + stack_size;
+
+	/* Save pointer to the thread on the stack, used by current macro */
+	*(unsigned long *)stack_base = (unsigned long)thread;
+	
+	/* these values are used by bmk_cpu_sched_bouncer() */
+	__asm__ __volatile__("stp %0, %1, [%2, #-16]!" :: 
+			   "r"(arg), "r"(f), "r"(stack_top));
+	//stack_push(&stack_top, (unsigned long)f);
+	//stack_push(&stack_top, (unsigned long)arg);
+	
+	tcb->btcb_sp = (unsigned long)stack_top;
+	tcb->btcb_ip = (unsigned long)bmk_cpu_sched_bouncer;
+}

--- a/lib/libbmk_core/arch/aarch64/cpu_sched_switch.S
+++ b/lib/libbmk_core/arch/aarch64/cpu_sched_switch.S
@@ -1,0 +1,35 @@
+#include <bmk-core/arm/asm.h>
+
+ENTRY(bmk_cpu_sched_bouncer)
+	ldp x0, x1, [sp], #16
+	br x1
+	bl bmk_sched_exit
+END(bmk_cpu_sched_bouncer)
+
+/*
+ * x0 = previous thread
+ * x1 = new thread
+ */
+ENTRY(bmk_cpu_sched_switch)
+	stp x29, x30, [sp, #-96]!
+	stp x19, x20, [sp, #16]
+	stp x21, x22, [sp, #32]
+	stp x23, x24, [sp, #48]
+	stp x25, x26, [sp, #64]
+	stp x27, x28, [sp, #80]
+	mov x9, sp
+	adr x10, 1f
+	stp x9, x10, [x0]
+	ldp x9, x10, [x1]
+	mov sp, x9
+	br x10
+	bl bmk_sched_exit
+1:	
+	ldp x19, x20, [sp, #16]
+	ldp x21, x22, [sp, #32]
+	ldp x23, x24, [sp, #48]
+	ldp x25, x26, [sp, #64]
+	ldp x27, x28, [sp, #80]
+	ldp x29, x30, [sp], #96
+	ret
+END(bmk_cpu_sched_switch)

--- a/lib/libbmk_core/sched.c
+++ b/lib/libbmk_core/sched.c
@@ -600,7 +600,6 @@ bmk_sched_exit_withtls(void)
 void
 bmk_sched_exit(void)
 {
-
 	bmk_sched_tls_free((void *)bmk_current->bt_tcb.btcb_tp);
 	bmk_sched_exit_withtls();
 }

--- a/lib/libbmk_rumpuser/rumpuser_synch.c
+++ b/lib/libbmk_rumpuser/rumpuser_synch.c
@@ -111,7 +111,6 @@ rumpuser_thread_create(void *(*f)(void *), void *arg, const char *thrname,
 void
 rumpuser_thread_exit(void)
 {
-
 	bmk_sched_exit();
 }
 
@@ -209,6 +208,12 @@ rumpuser_mutex_owner(struct rumpuser_mtx *mtx, struct lwp **lp)
 {
 
 	*lp = mtx->o;
+}
+
+int
+rumpuser_mutex_spin_p(struct rumpuser_mtx *mtx)
+{
+	return (mtx->flags & RUMPUSER_MTX_SPIN) != 0;
 }
 
 struct rumpuser_rw {

--- a/lib/librumprun_base/_lwp.c
+++ b/lib/librumprun_base/_lwp.c
@@ -248,7 +248,7 @@ rumprun_lwp_init(void)
 }
 
 int
-_lwp_park(clockid_t clock_id, int flags, const struct timespec *ts,
+_lwp_park(clockid_t clock_id, int flags, struct timespec *ts,
 	lwpid_t unpark, const void *hint, const void *unparkhint)
 {
 	int rv;

--- a/platform/hw/Makefile
+++ b/platform/hw/Makefile
@@ -31,6 +31,10 @@ SRCS+=		intr.c clock_subr.c kernel.c multiboot.c undefs.c
 include ../Makefile.inc
 include arch/${ARCHDIR}/Makefile.inc
 
+# Disable PIE, but need to check if compiler supports it
+LDFLAGS-$(call cc-option,-no-pie) += -no-pie
+LDFLAGS += $(LDFLAGS-y)
+
 OBJS:=	$(patsubst %.c,${RROBJ}/platform/%.o,${SRCS}) \
 	$(patsubst %.S,${RROBJ}/platform/%.o,${ASMS})
 
@@ -54,7 +58,7 @@ ${RROBJ}/platform/%.o: %.S
 	${CC} -D_LOCORE ${CPPFLAGS} ${CFLAGS} -c $< -o $@
 
 ${MAINOBJ}: ${OBJS} platformlibs
-	${CC} -nostdlib ${CFLAGS} -Wl,-r ${OBJS} -o $@ \
+	${CC} -nostdlib ${CFLAGS} ${LDFLAGS} -Wl,-r ${OBJS} -o $@ \
 	    -L${RROBJLIB}/libbmk_core -L${RROBJLIB}/libbmk_rumpuser \
 	    -Wl,--whole-archive -lbmk_rumpuser -lbmk_core -Wl,--no-whole-archive
 	${OBJCOPY} -w -G bmk_* -G rumpuser_* -G jsmn_* \

--- a/platform/solo5/Makefile
+++ b/platform/solo5/Makefile
@@ -8,12 +8,11 @@ default: all
 # Check if we're building for a supported target.
 supported= false
 # assume we're doing "make clean"
-MACHINE?= amd64
-ifeq (${MACHINE},amd64)
+ifeq (${MACHINE},$(filter ${MACHINE},amd64 evbarm64-el))
 supported:= true
 endif
 ifneq (${supported},true)
-$(error only supported target is x86, you have ${MACHINE})
+$(error supported targets is are x86-64 and aarch64, you have ${MACHINE})
 endif
 
 ARCHDIR?= ${MACHINE}
@@ -30,6 +29,10 @@ include ../Makefile.inc
 include arch/${ARCHDIR}/Makefile.inc
 
 OBJS:=	$(patsubst %.c,${RROBJ}/platform/%.o,${SRCS})
+
+# Disable PIE, but need to check if compiler supports it
+LDFLAGS-$(call cc-option,-no-pie) += -no-pie
+LDFLAGS += $(LDFLAGS-y)
 
 .PHONY:	clean cleandir all
 
@@ -55,7 +58,7 @@ $(eval $(call BUILDLIB_target,librumpnet_ukvmif,.))
 solo5libs: ${RROBJLIB}/librumpnet_ukvmif/librumpnet_ukvmif.a
 
 ${MAINOBJ}: ${OBJS} platformlibs solo5libs
-	${CC} -nostdlib ${CFLAGS} -Wl,-r ${OBJS} -o $@ \
+	${CC} -nostdlib ${CFLAGS} ${LDFLAGS} -Wl,-r ${OBJS} -o $@ \
 	    -L${RROBJLIB}/libbmk_core -L${RROBJLIB}/libbmk_rumpuser \
 	    -Wl,--whole-archive -lbmk_rumpuser -lbmk_core -Wl,--no-whole-archive
 	#${OBJCOPY} -w -G bmk_* -G jsmn_* -G solo5_app_main -G _start $@

--- a/platform/solo5/arch/evbarm64-el/Makefile.inc
+++ b/platform/solo5/arch/evbarm64-el/Makefile.inc
@@ -1,0 +1,5 @@
+SRCS+=	arch/evbarm64-el/machdep.c
+
+.PHONY: archdirs
+archdirs:
+	mkdir -p ${RROBJ}/platform/arch/evbarm64-el

--- a/platform/solo5/arch/evbarm64-el/kern.ldscript
+++ b/platform/solo5/arch/evbarm64-el/kern.ldscript
@@ -1,0 +1,75 @@
+ENTRY(_start)
+SECTIONS
+{
+	. = 0x100000;
+
+	/* Code */
+	_stext = . ;
+
+	.text :
+	{
+		*(.text)
+		*(.text.*)
+	}
+
+	. = ALIGN(0x1000);
+	_etext = . ;
+
+	/* Read-only data */
+	.rodata :
+	{
+		*(.rodata)
+		*(.rodata.*)
+	}
+	.eh_frame :
+	{
+		*(.eh_frame)
+	}
+
+	. = ALIGN(0x1000);
+	_erodata = .;
+
+	.tdata :
+	{
+		_tdata_start = . ;
+		*(.tdata)
+		_tdata_end = . ;
+	}
+	.tbss :
+	{
+		_tbss_start = . ;
+		*(.tbss)
+		_tbss_end = . ;
+	}
+
+	.initfini :
+	{
+		__init_array_start = . ;
+		*(SORT_BY_INIT_PRIORITY(.init_array.*))
+		*(SORT_BY_INIT_PRIORITY(.ctors*))
+		*(.init_array)
+		__init_array_end = . ;
+		__fini_array_start = . ;
+		*(SORT_BY_INIT_PRIORITY(.fini_array.*))
+		*(SORT_BY_INIT_PRIORITY(.dtors*))
+		*(.fini_array)
+		__fini_array_end = . ;
+	}
+
+	.data :
+	{
+		*(.data)
+	}
+
+	. = ALIGN(0x1000);
+	_edata = . ;
+	.bss :
+	{
+		*(.bss)
+		*(COMMON)
+	}
+	
+	. = ALIGN(0x1000);
+	_ebss = .;
+	_end = .;
+}

--- a/platform/solo5/arch/evbarm64-el/machdep.c
+++ b/platform/solo5/arch/evbarm64-el/machdep.c
@@ -1,0 +1,37 @@
+/*-
+ * Copyright (c) 2014, 2015 Antti Kantee.  All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <hw/kernel.h>
+
+#include <bmk-core/printf.h>
+#include <bmk-core/sched.h>
+unsigned long bmk_cpu_arm_curtcb;
+
+
+void
+bmk_platform_cpu_sched_settls(struct bmk_tcb *next)
+{
+        __asm__ __volatile__("msr tpidr_el0, %0" :: "r"(next->btcb_tp));
+}

--- a/platform/solo5/include/arch/aarch64/md.h
+++ b/platform/solo5/include/arch/aarch64/md.h
@@ -1,0 +1,12 @@
+#ifndef _BMK_ARCH_AARCH64_MD_H_
+#define _BMK_ARCH_AARCH64_MD_H_
+
+#include <hw/kernel.h>
+
+#include <bmk-core/arm/asm.h>
+
+#define BMK_THREAD_STACK_PAGE_ORDER 3
+#define BMK_THREAD_STACKSIZE ((1<<BMK_THREAD_STACK_PAGE_ORDER) \
+    * BMK_PCPU_PAGE_SIZE)
+
+#endif /* _BMK..._H_ */

--- a/platform/solo5/include/arch/aarch64/pcpu.h
+++ b/platform/solo5/include/arch/aarch64/pcpu.h
@@ -1,0 +1,7 @@
+#ifndef _BMK_PCPU_PCPU_H_
+#define _BMK_PCPU_PCPU_H_
+
+#define BMK_PCPU_PAGE_SHIFT 12UL
+#define BMK_PCPU_PAGE_SIZE (1<<BMK_PCPU_PAGE_SHIFT)
+
+#endif /* _BMK_PCPU_PCPU_H_ */

--- a/platform/solo5/librumpnet_ukvmif/if_virt.c
+++ b/platform/solo5/librumpnet_ukvmif/if_virt.c
@@ -304,7 +304,7 @@ virtif_start(struct ifnet *ifp)
 		}
 		if (i == LB_SH && m)
 			panic("lazy bum");
-		bpf_mtap(ifp, m0);
+		bpf_mtap(ifp, m0, BPF_D_OUT);
 
 		VIFHYPER_SEND(sc->sc_viu, io, i);
 
@@ -376,7 +376,7 @@ VIF_DELIVERPKT(struct iovec *iov, size_t iovlen)
 	if (passup) {
 		ifp->if_ipackets++;
 		m_set_rcvif(m, ifp);
-		bpf_mtap(ifp, m);
+		bpf_mtap(ifp, m, BPF_D_OUT);
 		ether_input(ifp, m);
 	} else {
 		m_freem(m);

--- a/platform/xen/Makefile
+++ b/platform/xen/Makefile
@@ -24,6 +24,10 @@ default: prepare links mini-os ${MAINOBJ} ${TARGETS}
 CPPFLAGS+= -isystem xen/include
 CPPFLAGS+= -no-integrated-cpp
 
+# Disable PIE, but need to check if compiler supports it
+LDFLAGS-$(call cc-option,-no-pie) += -no-pie
+LDFLAGS += $(LDFLAGS-y)
+
 CFLAGS += -fno-builtin
 
 rump-src-y += rumphyper_bio.c

--- a/platform/xen/xen/Makefile
+++ b/platform/xen/xen/Makefile
@@ -33,7 +33,9 @@ LDARCHLIB := -l$(ARCH_LIB_NAME)
 LDSCRIPT := $(TARGET_ARCH_DIR)/minios-$(XEN_TARGET_ARCH).lds
 LDFLAGS_FINAL := -T $(LDSCRIPT)
 
-LDFLAGS := -L$(abspath $(OBJ_DIR)/$(TARGET_ARCH_DIR))
+# Disable PIE, but need to check if compiler supports it
+LDFLAGS-$(call cc-option,-no-pie) += -no-pie
+LDFLAGS := -L$(abspath $(OBJ_DIR)/$(TARGET_ARCH_DIR)) $(LDFLAGS-y)
 
 # Prefixes for global API names. All other symbols in mini-os are localised
 # before linking with rumprun applications.

--- a/platform/xen/xen/minios.mk
+++ b/platform/xen/xen/minios.mk
@@ -7,8 +7,9 @@ debug = y
 # Define some default flags.
 # NB. '-Wcast-qual' is nasty, so I omitted it.
 DEF_CFLAGS += -fno-builtin -Wall -Werror -Wredundant-decls -Wno-format -Wno-redundant-decls
-DEF_CFLAGS += $(call cc-option,$(CC),-fno-stack-protector,)
-DEF_CFLAGS += $(call cc-option,$(CC),-fgnu89-inline)
+DEF_CFLAGS-$(call cc-option,-fno-stack-protector) += -fno-stack-protector
+DEF_CFLAGS-$(call cc-option,-fgnu89-inline) += -fgnu89-inline
+DEF_CFLAGS += $(DEF_CFLAGS-y)
 DEF_CFLAGS += -Wstrict-prototypes -Wnested-externs -Wpointer-arith -Winline
 DEF_CPPFLAGS += -D__XEN_INTERFACE_VERSION__=$(XEN_INTERFACE_VERSION)
 

--- a/travis_wait.sh
+++ b/travis_wait.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Copyright (c) 2016 Travis CI GmbH <contact@travis-ci.org>
+#
+# SPDX-License-Identifier: MIT
+#
+# Based on the travis-ci/travis-build
+
+travis_jigger() {
+  # helper method for travis_wait()
+  local cmd_pid=$1
+  shift
+  local timeout=$1 # in minutes
+  shift
+  local count=0
+
+  # clear the line
+  echo -e "\n"
+
+  while [ $count -lt $timeout ]; do
+    count=$(($count + 1))
+    echo -ne "Still running ($count of $timeout): $@\r"
+    sleep 60
+  done
+
+  echo -e "\n${ANSI_RED}Timeout (${timeout} minutes) reached. Terminating \"$@\"${ANSI_RESET}\n"
+  kill -9 $cmd_pid
+}
+
+travis_wait() {
+  local timeout=$1
+
+  if [[ $timeout =~ ^[0-9]+$ ]]; then
+    # looks like an integer, so we assume it's a timeout
+    shift
+  else
+    # default value
+    timeout=20
+  fi
+
+  local cmd="$@"
+  local log_file=travis_wait_$$.log
+
+  $cmd &>$log_file &
+  local cmd_pid=$!
+
+  travis_jigger $! $timeout $cmd &
+  local jigger_pid=$!
+  local result
+
+  {
+    wait $cmd_pid 2>/dev/null
+    result=$?
+    ps -p$jigger_pid &>/dev/null && kill $jigger_pid
+  } || return 1
+
+  if [ $result -eq 0 ]; then
+    echo -e "\n${ANSI_GREEN}The command \"$TRAVIS_CMD\" exited with $result.${ANSI_RESET}"
+  else
+    echo -e "\n${ANSI_RED}The command \"$TRAVIS_CMD\" exited with $result.${ANSI_RESET}"
+  fi
+
+  echo -e "\n${ANSI_GREEN}Log:${ANSI_RESET}\n"
+  tail -n 200 $log_file
+
+  return $result
+}
+
+travis_wait $@


### PR DESCRIPTION
- add aarch64 platform for rumprun
- update src-netbsd (custom fixes needed for aarch64 & rumprun)

*Stack protection in NetBSD is off (pending further investigation)

Please note that buildrump.sh & src-netbsd both point to forked repos.