### PR TITLE
Update Solo5 to v0.6.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.ukvm
 *.seccomp
 *dummy
+obj-*
+rumprun-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
   - sudo apt-get update -y
   - sudo apt-get install qemu-kvm libxen-dev libseccomp-dev bats genisoimage sudo iproute2 wget -y
   - sudo apt-get install --only-upgrade binutils gcc -y
+  - bash travis_wait.sh 60 git clone https://github.com/Solo5/solo5.git
   - bash travis_wait.sh 60 git submodule update --init
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - NOGCCERROR=1 ./build-rr.sh -o myobj -j16 -qq ${KERNONLY} ${PLATFORM} ${EXTRAFLAGS}
   - . ./myobj/config
   - ./tests/buildtests.sh ${KERNONLY}
-  - ./tests/runtests.sh ${TESTS}
+  - sudo -E ./tests/runtests.sh ${TESTS}
   - sudo RUMPRUN_MKCONF=${RUMPRUN_MKCONF} STACK=${TESTS} bats ./tests/bats/tests.bats
 
 # The sudo above is because there is a test that needs to create a TAP device

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-6
-      - g++-6
+      - gcc-7
+      - g++-7
 
 git:
   submodules: false
@@ -26,7 +26,7 @@ env:
   - PLATFORM=hw MACHINE=x86_64 TESTS=none KERNONLY=-k EXTRAFLAGS= 
 
 script:
-  - export CC=gcc-6
+  - export CC=gcc-7
   - NOGCCERROR=1 ./build-rr.sh -o myobj -j16 -qq ${KERNONLY} ${PLATFORM} ${EXTRAFLAGS}
   - . ./myobj/config
   - ./tests/buildtests.sh ${KERNONLY}

--- a/build-rr.sh
+++ b/build-rr.sh
@@ -389,6 +389,14 @@ buildrump ()
 	#
 	[ `${CC} -dumpversion | cut -f1 -d.` -ge 7 ] \
 		&& extracflags="$extracflags -F CPPFLAGS=-Wimplicit-fallthrough=0"
+	[ `${CC} -dumpversion | cut -f1 -d.` -ge 7 ] \
+		&& extracflags="$extracflags -F CPPFLAGS=-Wno-maybe-uninitialized"
+	[ `${CC} -dumpversion | cut -f1 -d.` -ge 7 ] \
+		&& extracflags="$extracflags -F CPPFLAGS=-Wno-cast-function-type"
+	[ `${CC} -dumpversion | cut -f1 -d.` -ge 7 ] \
+		&& extracflags="$extracflags -F CPPFLAGS=-Wno-tautological-compare"
+	[ `${CC} -dumpversion | cut -f1 -d.` -ge 7 ] \
+		&& extracflags="$extracflags -F CPPFLAGS=-Wno-attributes"
 
 
 	extracflags="${extracflags} ${TLSCFLAGS} ${FREQ_SETUP}"

--- a/build-rr.sh
+++ b/build-rr.sh
@@ -591,7 +591,10 @@ dobuild ()
 
 	buildpci
 
-	[ "${PLATFORM}" = "solo5" ] && make -C ${SOLO5SRC}
+	[ "${PLATFORM}" = "solo5" ] && \
+	  ( cd ${SOLO5SRC} \
+	    && ./configure.sh \
+	    && make)
 
 	# do final build of the platform bits
 	( cd ${PLATFORMDIR} \

--- a/platform/solo5/Makefile
+++ b/platform/solo5/Makefile
@@ -18,6 +18,9 @@ endif
 ARCHDIR?= ${MACHINE}
 HW_MACHINE_ARCH?= ${MACHINE_GNU_ARCH}
 
+SOLO5DIR?=../../solo5
+ELFTOOL?=${SOLO5DIR}/elftool/solo5-elftool
+
 # XXX simplify kern.ldscript (some stuff is not needed anymore on solo5)
 # of even better, we could use the solo5 linker script
 LDSCRIPT:=	$(abspath arch/${ARCHDIR}/kern.ldscript)
@@ -29,6 +32,7 @@ include ../Makefile.inc
 include arch/${ARCHDIR}/Makefile.inc
 
 OBJS:=	$(patsubst %.c,${RROBJ}/platform/%.o,${SRCS})
+OBJS+= ${RROBJ}/platform/manifest.o
 
 # Disable PIE, but need to check if compiler supports it
 LDFLAGS-$(call cc-option,-no-pie) += -no-pie
@@ -52,6 +56,12 @@ ${RROBJ}/platform/%.o: %.c
 
 ${RROBJ}/platform/%.o: %.S
 	${CC} -D_LOCORE ${CPPFLAGS} ${CFLAGS} -c $< -o $@
+
+${RROBJ}/platform/manifest.o: ${RROBJ}/platform/manifest.c
+	${CC} ${CPPFLAGS} ${CFLAGS} -c $< -o $@
+
+${RROBJ}/platform/manifest.c: manifest.json
+	${ELFTOOL} gen-manifest $< $@
 
 $(eval $(call BUILDLIB_target,librumpnet_ukvmif,.))
 

--- a/platform/solo5/arch/amd64/kern.ldscript
+++ b/platform/solo5/arch/amd64/kern.ldscript
@@ -1,92 +1,160 @@
-OUTPUT_FORMAT("elf64-x86-64", "elf64-x86-64", "elf64-x86-64")
-OUTPUT_ARCH(i386:x86-64)
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * This is the custom linker script for the Solo5 'spt' target.
+ *
+ * The script is tested to work with a minimal set of input sections. If there
+ * are unexpected input sections not named here, the result will probably not be
+ * correct.
+ */
+TEXT_START = 0x100000;
+
 ENTRY(_start)
 
-SECTIONS
-{
-	. = 0x100000;
-	_begin = . ;
+/*
+ * Program headers: In order to force the linker to place each of our NOTEs
+ * into a separate PT_NOTE header, we need lay these out explicitly.
+ */
+PHDRS {
+    interp PT_INTERP;
+    text PT_LOAD FLAGS(5); /* No FILEHDR or PHDRS, force R/E only.
+                              FLAGS values come from PF_x in elf.h */
+    data PT_LOAD;
+    note.not-openbsd PT_NOTE; /* Must come first. */
+    note.abi PT_NOTE;
+    note.manifest PT_NOTE;
+}
 
-	.bootstrap :
-	{
-		*(.bootstrap)
-	}
+/*
+ * Output sections.
+ */
+SECTIONS {
+    . = TEXT_START; /* No + SIZEOF_HEADERS */
 
-	. = ALIGN(0x1000);
+    /*
+     * :text: The following input sections are placed in the R/E :text segment.
+     */
+    _stext = .;
 
-        /* Code */
-	_stext = . ;
+    .interp : {
+        *(.interp)
+    } :interp :text
 
-	.text :
-	AT (ADDR(.text))
-	{
-		*(.text)
-		*(.text.*)
-		*(.stub)
-		*(.note*)
-	}
-	_etext = . ;
+    .text :
+    {
+        *(.text)
+        *(.text.*)
+    } :text
 
-	.rodata :
-	AT (LOADADDR(.text) + (ADDR(.rodata) - ADDR(.text)))
-	{
-		*(.rodata)
-		*(.rodata.*)
-	}
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+    _etext = .;
 
-        _erodata = .;
+    /* Read-only data */
 
-	.initfini :
-	AT (LOADADDR(.text) + (ADDR(.initfini) - ADDR(.text)))
-	{
-		__init_array_start = . ;
-		*(SORT_BY_INIT_PRIORITY(.init_array.*))
-		*(SORT_BY_INIT_PRIORITY(.ctors*))
-		*(.init_array)
-		__init_array_end = . ;
-		__fini_array_start = . ;
-		*(SORT_BY_INIT_PRIORITY(.fini_array.*))
-		*(SORT_BY_INIT_PRIORITY(.dtors*))
-		*(.fini_array)
-		__fini_array_end = . ;
-	}
+    /* For Spt, the ABI and MFT NOTEs are read-only and can be in :text. */
+    .note.solo5.manifest :
+    {
+        *(.note.solo5.manifest*)
+    } :text :note.manifest
+    .note.solo5.abi :
+    {
+        *(.note.solo5.abi*)
+    } :text :note.abi
+    .note.solo5.not-openbsd :
+    {
+        *(.note.solo5.not-openbsd*)
+    } :text :note.not-openbsd
 
-	. = ALIGN(0x1000);
+    .rodata :
+    {
+        *(.rodata)
+        *(.rodata.*)
+    } :text
+    .eh_frame :
+    {
+        *(.eh_frame)
+    }
 
-	_data_start = .;
-	.data :
-	AT (LOADADDR(.text) + (ADDR(.data) - ADDR(.text)))
-	{
-		*(.data)
-		*(.data.*)
-	}
-	.tdata : {
-		_tdata_start = . ;
-		*(.tdata)
-		_tdata_end = . ;
-	}
-	_edata = . ;
-	.tbss : {
-		_tbss_start = . ;
-		*(.tbss)
-		_tbss_end = . ;
-	}
+    .initfini :
+    {
+        __init_array_start = . ;
+        *(SORT_BY_INIT_PRIORITY(.init_array.*))
+        *(SORT_BY_INIT_PRIORITY(.ctors*))
+        *(.init_array)
+        __init_array_end = . ;
+        __fini_array_start = . ;
+        *(SORT_BY_INIT_PRIORITY(.fini_array.*))
+        *(SORT_BY_INIT_PRIORITY(.dtors*))
+        *(.fini_array)
+        __fini_array_end = . ;
+    }
 
-	__bss_start = . ;
-	.bss :
-	AT (LOADADDR(.text) + (ADDR(.bss) - ADDR(.text)))
-	{
-		*(.bss)
-		*(.bss.*)
-		*(COMMON)
-	}
-	.lbss :
-	AT (LOADADDR(.text) + (ADDR(.lbss) - ADDR(.text)))
-	{
-		*(.lbss)
-		*(.lbss.*)
-		*(LARGE_COMMON)
-	}
-	_ebss = . ;
-	_end = . ;
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+    _erodata = .;
+
+    /*
+     * :data: The following input sections are placed in the R/W :data segment.
+     */
+
+    /* Read-write data (initialized) */
+    .got :
+    {
+        *(.got.plt)
+        *(.got)
+    } :data
+    .data :
+    {
+        *(.data)
+        *(.data.*)
+    }
+    .tdata :
+    {
+        _tdata_start = .;
+        *(.tdata)
+        _tdata_end = .;
+    }
+
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+    _edata = .;
+
+    /* Read-write data (uninitialized) */
+    .tbss :
+    {
+        _tbss_start = .;
+        *(.tbss)
+        _tbss_end = .;
+    }
+    .bss :
+    {
+        *(.bss)
+        *(COMMON)
+    }
+
+    . = ALIGN(CONSTANT(MAXPAGESIZE));
+    _ebss = .;
+    _end = .;
+
+    /* We are not building a GNU executable, so discard any default NOTEs the
+       toolchain might generate to prevent any surprises in the final layout. */
+    /DISCARD/ : {
+        *(.note.gnu.*)
+    }
 }

--- a/platform/solo5/boot.c
+++ b/platform/solo5/boot.c
@@ -64,5 +64,5 @@ int solo5_app_main(const struct solo5_start_info *si)
 	bmk_sched_startmain(bmk_mainthread, (void *)solo5_cmdline);
 
 	/* not reachable */
-	solo5_exit(0);
+	solo5_exit(SOLO5_EXIT_SUCCESS);
 }

--- a/platform/solo5/cons.c
+++ b/platform/solo5/cons.c
@@ -55,5 +55,4 @@ void
 cons_puts(const char *s)
 {
 	solo5_console_write(s, strlen(s));
-
 }

--- a/platform/solo5/include/mft_abi.h
+++ b/platform/solo5/include/mft_abi.h
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2015-2019 Contributors as noted in the AUTHORS file
+ *
+ * This file is part of Solo5, a sandboxed execution environment.
+ *
+ * Permission to use, copy, modify, and/or distribute this software
+ * for any purpose with or without fee is hereby granted, provided
+ * that the above copyright notice and this permission notice appear
+ * in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+ * WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+ * AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+ * mft_abi.h: Application manifest ABI definitions.
+ *
+ * This header file must be kept self-contained with no external dependencies
+ * other than C99 headers. It defines the binary structures of the application
+ * manifest.
+ *
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef MFT_ABI_H
+#define MFT_ABI_H
+
+/*
+ * MFT_VERSION is the manifest ABI version.
+ */
+#define MFT_VERSION 1
+
+/*
+ * Supported manifest entry types.
+ */
+typedef enum mft_type {
+    MFT_DEV_BLOCK_BASIC = 1,
+    MFT_DEV_NET_BASIC,
+    MFT_RESERVED_FIRST = (1U << 30)
+} mft_type_t;
+
+/*
+ * MFT_DEV_BLOCK_BASIC (basic block device) properties.
+ */
+struct mft_block_basic {
+    uint64_t capacity;
+    uint16_t block_size;
+};
+
+/*
+ * MFT_DEV_NET_BASIC (basic network device) properties.
+ */
+struct mft_net_basic {
+    uint8_t mac[6];
+    uint16_t mtu;
+};
+
+#define MFT_NAME_SIZE 68        /* Bytes, including string terminator */
+#define MFT_NAME_MAX  67        /* Characters */
+
+/*
+ * Manifest entry (struct mft.e[]).
+ */
+struct mft_entry {
+    char name[MFT_NAME_SIZE];
+    mft_type_t type;
+    union {
+        struct mft_block_basic block_basic;
+        struct mft_net_basic net_basic;
+    } u;
+    union {
+        int hostfd;             /* Backing host descriptor OR */
+        void *data;             /* backing object / structure */
+    } b;
+    bool attached;              /* Device attached? */
+};
+
+/*
+ * Maximum supported number of manifest entires.
+ */
+#define MFT_MAX_ENTRIES 64
+
+/*
+ * Ensure that MFT_MAX_ENTRIES is not larger than the number of bits in a
+ * solo5_handle_set_t (actually a uint64_t in disguise, but we don't want to
+ * depend on solo5.h here).
+ */
+_Static_assert(MFT_MAX_ENTRIES <= (sizeof(uint64_t) * 8),
+        "MFT_MAX_ENTRIES too large for solo5_handle_set_t");
+
+/*
+ * MFT_ENTRIES is defined by elftool when a manifest is being *defined*.
+ * If it is not defined, then (struct mft).e will become a VLA, this is
+ * intentional.
+ */
+#ifndef MFT_ENTRIES
+#define MFT_ENTRIES
+#else
+_Static_assert(MFT_ENTRIES <= MFT_MAX_ENTRIES, "MFT_ENTRIES out of range");
+#endif
+
+/*
+ * Top-level manifest structure.
+ */
+struct mft {
+    uint32_t version;
+    uint32_t entries;
+    struct mft_entry e[MFT_ENTRIES];
+};
+
+/*
+ * HERE BE DRAGONS.
+ *
+ * The following structures and macros are used to declare a Solo5 "MFT1"
+ * format note at link time. This is somewhat tricky, as we need to ensure all
+ * structures are aligned correctly.
+ */
+#define MFT1_NOTE_NAME "Solo5"
+#define MFT1_NOTE_TYPE 0x3154464d /* "MFT1" */
+
+/*
+ * Defines an Elf64_Nhdr with n_name filled in and padded to a 4-byte boundary,
+ * i.e. the common part of a Solo5-owned Nhdr.
+ */
+struct mft1_nhdr {
+    uint32_t n_namesz;
+    uint32_t n_descsz;
+    uint32_t n_type;
+    char n_name[(sizeof(MFT1_NOTE_NAME) + 3) & -4];
+};
+
+_Static_assert((sizeof(struct mft1_nhdr)) ==
+        (sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t) + 8),
+        "struct mft1_nhdr alignment issue");
+
+/*
+ * Defines the entire note (header, descriptor content).
+ */
+struct mft1_note {
+    struct mft1_nhdr h;
+    struct mft m;
+};
+
+/*
+ * Internal alignment of (m) within struct mft1_note. Must be passed to
+ * elf_load_note() as note_align when loading.
+ */
+#define MFT1_NOTE_ALIGN offsetof(struct { char c; struct mft m; }, m)
+
+_Static_assert((offsetof(struct mft1_note, m) & (MFT1_NOTE_ALIGN - 1)) == 0,
+        "struct mft1_note.m is not aligned to a MFT1_NOTE_ALIGN boundary");
+
+/*
+ * Maximum descsz of manifest ELF note descriptor (content), including
+ * internal alignment.
+ */
+#define MFT1_NOTE_MAX_SIZE ((sizeof (struct mft1_note) - \
+         sizeof (struct mft1_nhdr)) + \
+        (MFT_MAX_ENTRIES * sizeof (struct mft_entry)))
+
+/*
+ * Declare a Solo5 "MFT1" format NOTE.
+ *
+ * Structure must be aligned to a 4-byte boundary (or possibly an 8-byte
+ * boundary, but ELF64 toolchains seem happy with the current arrangement...
+ * the specifications are mess).
+ */
+#define MFT1_NOTE_DECLARE_BEGIN \
+const struct mft1_note __solo5_mft1_note \
+__attribute__ ((section (".note.solo5.manifest"), aligned(4))) \
+= { \
+    .h = { \
+        .n_namesz = sizeof(MFT1_NOTE_NAME), \
+        .n_descsz = (sizeof(struct mft1_note) - \
+                    sizeof(struct mft1_nhdr)), \
+        .n_type = MFT1_NOTE_TYPE, \
+        .n_name = MFT1_NOTE_NAME \
+    }, \
+    .m =
+
+#define MFT1_NOTE_DECLARE_END };
+
+#endif /* MFT_ABI_H */

--- a/platform/solo5/kernel.c
+++ b/platform/solo5/kernel.c
@@ -51,7 +51,7 @@ bmk_platform_halt(const char *panicstring)
 	if (panicstring)
 		bmk_printf("PANIC: %s\n", panicstring);
 	bmk_printf("halted\n");
-	solo5_exit(0);
+	solo5_exit(SOLO5_EXIT_SUCCESS);
 }
 
 void rumpcomp_ukvmif_receive(void);
@@ -59,7 +59,10 @@ void rumpcomp_ukvmif_receive(void);
 void
 bmk_platform_cpu_block(bmk_time_t until_ns)
 {
-	if (solo5_yield(until_ns)) {
+	solo5_handle_set_t ready_set;
+
+	solo5_yield(until_ns, &ready_set);
+	if (ready_set != 0) {
 		rumpcomp_ukvmif_receive();
 	}
 }

--- a/platform/solo5/manifest.json
+++ b/platform/solo5/manifest.json
@@ -1,0 +1,9 @@
+{
+  "type": "solo5.manifest",
+  "version": 1,
+  "devices":
+  [
+    { "name": "rootfs", "type": "BLOCK_BASIC" },
+    { "name": "tap", "type": "NET_BASIC" }
+  ]
+}

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,5 @@
+bats/test_dir
+bats/*.ext2
+bats/*.iso
+cmake/build
+testrun.*

--- a/tests/buildtests.sh
+++ b/tests/buildtests.sh
@@ -75,6 +75,7 @@ test_apptools()
 
 	if [ -n "${TESTCMAKE}" ]; then
 		(
+			rm -rf cmake/build
 			mkdir -p cmake/build
 			cd cmake/build
 			cmake -DCMAKE_TOOLCHAIN_FILE=${RRDEST}/rumprun-${MACHINE_GNU_ARCH}/share/${TOOLTUPLE}-toolchain.cmake ..

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.12.4)
 project(Test C)
 
 include(CheckIncludeFile)


### PR DESCRIPTION
The current rumprun port uses solo5@120848b, which is committed over 2 years ago. This PR proposes updates Solo5 to the latest tagged version, v0.6.6. There are several differences between the current and v0.6.6.

1. Commandline option changes:
The newer version of Solo5 accepts multiple block devices and network devices. This change causes the command line option changes.

2. `manifest.json` introduced:
The newer version of Solo5 requires `manifest.json` to define attached devices at runtime. This file is compiled to an object file via a C file on compile-time. Thus, the rumprun port has to have predefined `manifest.json` and the pre-compiled object file before run. I added the "rootfs" block device and the "tap" network device for this PR. The devices cannot be optional, so we have to supply them as run-time arguments even if they are not used in the application.

I think issue #28 can be fixed once this PR merged.